### PR TITLE
Use the first direct command queue

### DIFF
--- a/Source/Main/D3DRenderer.cpp
+++ b/Source/Main/D3DRenderer.cpp
@@ -777,7 +777,7 @@ namespace ER
 
 	void D3DRenderer::HookExecuteCommandLists(ID3D12CommandQueue* queue, UINT NumCommandLists, ID3D12CommandList* ppCommandLists) 
 	{
-		if (!g_D3DRenderer->m_CommandQueue)
+		if (!g_D3DRenderer->m_CommandQueue && queue->GetDesc().Type == D3D12_COMMAND_LIST_TYPE_DIRECT)
 			g_D3DRenderer->m_CommandQueue = queue;
 
 		g_D3DRenderer->oExecuteCommandLists(queue, NumCommandLists, ppCommandLists);


### PR DESCRIPTION
The command lists that are being submitted in D3DRenderer::Overlay require that the queue is a direct queue.