### PR TITLE
Show only actively applied status bars

### DIFF
--- a/Source/Main/PostureBarUI.cpp
+++ b/Source/Main/PostureBarUI.cpp
@@ -168,13 +168,18 @@ namespace ER
                         for (size_t i = static_cast<size_t>(EERDataType::STATUSES) + 1; i < static_cast<size_t>(EERDataType::MAX); ++i)
                         {
                             EERDataType statusEffectType = static_cast<EERDataType>(i);
-                            if (bossPostureBar->drawBar[statusEffectType])
+                            if (!bossPostureBar->drawBar[statusEffectType])
                             {
-                                float fillRatio = bossPostureBar->barDatas[statusEffectType].GetRatio();
-
-                                drawBar(EPostureBarType::Boss, statusEffectType, viewportPosition, statusBarSize, fillRatio);
-                                viewportPosition.y += BossPostureBarData::nextStatusBarDiffScreenY;
+                                continue;
                             }
+                            float fillRatio = bossPostureBar->barDatas[statusEffectType].GetRatio();
+
+                            if (fillRatio <= 0.0f)
+                            {
+                                continue;
+                            }
+                            drawBar(EPostureBarType::Boss, statusEffectType, viewportPosition, statusBarSize, fillRatio);
+                            viewportPosition.y += BossPostureBarData::nextStatusBarDiffScreenY;
                         }
                     }
                 }
@@ -239,13 +244,17 @@ namespace ER
                         for (size_t i = static_cast<size_t>(EERDataType::STATUSES) + 1; i < static_cast<size_t>(EERDataType::MAX); ++i)
                         {
                             EERDataType statusEffectType = static_cast<EERDataType>(i);
-                            if (entityPostureBar->drawBar[statusEffectType])
+                            if (!entityPostureBar->drawBar[statusEffectType])
                             {
-                                float fillRatio = entityPostureBar->barDatas[statusEffectType].GetRatio();
-
-                                drawBar(EPostureBarType::Entity, statusEffectType, viewportPosition, statusBarSize, fillRatio);
-                                viewportPosition.y += EntityPostureBarData::nextStatusBarDiffScreenY;
+                                continue;
                             }
+                            float fillRatio = entityPostureBar->barDatas[statusEffectType].GetRatio();
+
+                            if (fillRatio <= 0.0f) {
+                                continue;
+                            }
+                            drawBar(EPostureBarType::Entity, statusEffectType, viewportPosition, statusBarSize, fillRatio);
+                            viewportPosition.y += EntityPostureBarData::nextStatusBarDiffScreenY;
                         }
                     }
                 }


### PR DESCRIPTION
I like having status bars, but don't like the bloat of several on-screen. If I ever swap weapons with a different status effect, then I would rather not restart the game to enable and disable one or two bars at a time. Trying to overlap them with different alpha values didn't work well either.

So the code was modified to hide the extra status bars until the user actively applies them. If the boss or entity regens the status resistance, then the bar will hide again. 